### PR TITLE
feeds.conf.default: Switch branch to the openwrt-23.05

### DIFF
--- a/feeds.conf.default
+++ b/feeds.conf.default
@@ -1,7 +1,7 @@
-src-git packages https://github.com/immortalwrt/packages.git
-src-git luci https://github.com/immortalwrt/luci.git
-src-git routing https://git.openwrt.org/feed/routing.git
-src-git telephony https://git.openwrt.org/feed/telephony.git
+src-git packages https://github.com/immortalwrt/packages.git;openwrt-23.05
+src-git luci https://github.com/immortalwrt/luci.git;openwrt-23.05
+src-git routing https://github.com/openwrt/routing.git;openwrt-23.05
+src-git telephony https://github.com/openwrt/telephony.git;openwrt-23.05
 src-git nss_packages https://github.com/qosmio/nss-packages.git;NSS-12.5-K6.x
 src-git sqm_scripts_nss https://github.com/qosmio/sqm-scripts-nss.git
 #src-git video https://github.com/openwrt/video.git


### PR DESCRIPTION
The master branch is updated too quickly, and there are problems with some plugins, such as upnp.