### PR TITLE
Add Swaiot S10-SKY support

### DIFF
--- a/target/linux/qualcommax/dts/ipq8071-s10sky.dts
+++ b/target/linux/qualcommax/dts/ipq8071-s10sky.dts
@@ -1,0 +1,388 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/* Copyright (c) 2025, oldcat <oldcat@126.com> */
+
+/dts-v1/;
+
+#include "ipq8074-512m.dtsi"
+#include "ipq8074-ac-cpu.dtsi"
+#include "ipq8074-ess.dtsi"
+#include "ipq8074-nss.dtsi"
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+
+/ {
+	model = "Swaiot S10-SKY";
+	compatible = "swaiot,s10sky", "qcom,ipq8074";
+
+	aliases {
+		serial0 = &blsp1_uart5;
+		/*
+		 * Aliases as required by u-boot
+		 * to patch MAC addresses
+		 */
+		ethernet0 = &dp5;
+		ethernet1 = &dp4;
+		ethernet2 = &dp3;
+	};
+
+	chosen {
+		stdout-path = "serial0:115200n8";
+		bootargs-append = " root=/dev/ubiblock0_1 swiotlb=1 coherent_pool=2M";
+	};
+
+	keys {
+		compatible = "gpio-keys";
+
+		wps {
+			label = "wps";
+			linux,code = <KEY_WPS_BUTTON>;
+			gpios = <&tlmm 50 GPIO_ACTIVE_LOW>;
+		};
+
+		reset {
+			label = "reset";
+			linux,code = <KEY_RESTART>;
+			gpios = <&tlmm 34 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		4gyellow {
+			label = "4gyellow";
+			gpios = <&tlmm 42 GPIO_ACTIVE_HIGH>;
+		};
+
+		4gblue {
+			label = "4gblue";
+			gpios = <&tlmm 43 GPIO_ACTIVE_HIGH>;
+		};
+
+		blue {
+			label = "blue";
+			gpios = <&tlmm 51 GPIO_ACTIVE_LOW>;
+		};
+
+		red {
+			label = "red";
+			gpios = <&tlmm 52 GPIO_ACTIVE_LOW>;
+		};
+
+		ethblue {
+			label = "ethblue";
+			gpios = <&tlmm 55 GPIO_ACTIVE_LOW>;
+		};
+
+		ethyellow {
+			label = "ethyellow";
+			gpios = <&tlmm 56 GPIO_ACTIVE_LOW>;
+		};
+
+		5gblue {
+			label = "5gblue";
+			gpios = <&tlmm 63 GPIO_ACTIVE_HIGH>;
+		};
+
+		5gyellow {
+			label = "5gyellow";
+			gpios = <&tlmm 64 GPIO_ACTIVE_HIGH>;
+		};
+	};
+};
+
+&tlmm {
+	mdio_pins: mdio-pins {
+		mdc {
+			pins = "gpio68";
+			function = "mdc";
+			drive-strength = <8>;
+			bias-pull-up;
+		};
+
+		mdio {
+			pins = "gpio69";
+			function = "mdio";
+			drive-strength = <8>;
+			bias-pull-up;
+		};
+
+		mux_2 {
+			pins = "gpio25";
+			function = "gpio";
+			bias-pull-up;
+		};
+
+		mux_3 {
+			pins = "gpio48";
+			function = "gpio";
+			bias-pull-up;
+		};
+	};
+
+	ws223 {
+		mux {
+			pins = "gpio46", "gpio47";
+			function = "gpio";
+			drive-strength = <8>;
+			bias-pull-down;
+		};
+	};
+
+	pcie0_default_state: pcie0_default_state {
+		pcie0_wake {
+			drive-strength = <8>;
+			function = "pcie0_wake";
+			pins = "gpio59";
+			bias-pull-down;
+		};
+
+		pcie0_rst {
+			drive-strength = <8>;
+			function = "pcie0_rst";
+			pins = "gpio58";
+			bias-pull-down;
+		};
+	};
+
+	pcie_sdx_gpio: pcie_sdx_gpio {
+		ap2mdm_err_ftl {
+			pins = "gpio27";
+			function = "gpio";
+			drive-strength = <8>;
+			bias-pull-down;
+		};
+
+		ap2mdm_gp_rst_n {
+			pins = "gpio29";
+			function = "gpio";
+			drive-strength = <8>;
+			output-high;
+		};
+
+		sdx_pon_gpio58 {
+			pins = "gpio58";
+			function = "gpio";
+			drive-strength = <8>;
+			bias-pull-up;
+			output-high;
+		};
+
+		sdx_pon_gpio30 {
+			pins = "gpio30";
+			function = "gpio";
+			drive-strength = <8>;
+			bias-pull-up;
+			output-high;
+		};
+
+		sdx_pon_gpio35 {
+			pins = "gpio35";
+			function = "gpio";
+			drive-strength = <8>;
+			bias-pull-up;
+			output-high;
+		};
+
+		mdm2ap_err_ftl {
+			pins = "gpio33";
+			function = "gpio";
+			drive-strength = <8>;
+			bias-pull-down;
+		};
+
+		ap2mdm_status {
+			pins = "gpio26";
+			function = "gpio";
+			drive-strength = <8>;
+			bias-pull-up;
+			output-high;
+		};
+	};
+};
+
+&blsp1_spi1 {
+	pinctrl-0 = <&spi_0_pins>;
+	pinctrl-names = "default";
+	cs-select = <0>;
+	status = "okay";
+
+	flash@0 {
+		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
+		reg = <0>;
+		spi-max-frequency = <50000000>;
+		};
+	};
+
+&blsp1_uart5 {
+	status = "okay";
+};
+
+&cryptobam {
+	status = "okay";
+};
+
+&crypto {
+	status = "okay";
+};
+
+&prng {
+	status = "okay";
+};
+
+&qpic_bam {
+	status = "okay";
+};
+
+&qpic_nand {
+	status = "okay";
+
+	nand@0 {
+		reg = <0>;
+		nand-ecc-strength = <8>;
+		nand-ecc-step-size = <512>;
+		nand-bus-width = <8>;
+
+		partitions {
+			compatible = "qcom,smem-part";
+		};
+	};
+};
+
+&qusb_phy_0 {
+	status = "okay";
+};
+
+&qusb_phy_1 {
+	status = "okay";
+};
+
+&ssphy_0 {
+	status = "okay";
+};
+
+&ssphy_1 {
+	status = "okay";
+};
+
+&usb_0 {
+	status = "okay";
+};
+
+&usb_1 {
+	status = "okay";
+};
+
+&mdio {
+	status = "okay";
+	pinctrl-0 = <&mdio_pins>;
+	pinctrl-names = "default";
+	reset-gpios = <&tlmm 37 GPIO_ACTIVE_LOW>;
+
+	ethernet-phy-package@0 {
+		compatible = "qcom,qca8075-package";
+		#address-cells = <1>;
+		#size-cells = <0>;
+		reg = <0>;
+
+		qcom,package-mode = "qsgmii";
+
+		qca8075_2: ethernet-phy@2 {
+			compatible = "ethernet-phy-ieee802.3-c22";
+			reg = <2>;
+		};
+
+		qca8075_3: ethernet-phy@3 {
+			compatible = "ethernet-phy-ieee802.3-c22";
+			reg = <3>;
+		};
+	};
+
+	qca8081: ethernet-phy@24 {
+	compatible = "ethernet-phy-id004d.d101";
+	reg = <24>;
+	reset-deassert-us = <10000>;
+	reset-gpios = <&tlmm 48 GPIO_ACTIVE_LOW>;
+
+	leds {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		led@0 {
+			reg = <0>;
+			color = <LED_COLOR_ID_GREEN>;
+			function = LED_FUNCTION_WAN;
+			default-state = "keep";
+			};
+		};
+	};
+};
+
+&switch {
+	status = "okay";
+
+	switch_lan_bmp = <(ESS_PORT3 | ESS_PORT4)>; /* lan port bitmap */
+	switch_wan_bmp = <ESS_PORT5>; /* wan port bitmap */
+	switch_mac_mode = <MAC_MODE_QSGMII>; /* mac mode for uniphy instance0*/
+	switch_mac_mode1 = <MAC_MODE_SGMII_PLUS>; /* mac mode for uniphy instance1*/
+
+	qcom,port_phyinfo {
+		port@3 {
+			port_id = <3>;
+			phy_address = <2>;
+		};
+		port@4 {
+			port_id = <4>;
+			phy_address = <3>;
+		};
+		port@5 {
+			port_id = <5>;
+			phy_address = <24>;
+			port_mac_sel = "QGMAC_PORT";
+		};
+	};
+};
+
+&edma {
+	status = "okay";
+};
+
+&dp3 {
+	status = "okay";
+	phy-mode = "qsgmii";
+	phy-handle = <&qca8075_2>;
+	label = "lan2";
+};
+
+&dp4 {
+	status = "okay";
+	phy-mode = "qsgmii";
+	phy-handle = <&qca8075_3>;
+	label = "lan1";
+};
+
+&dp5 {
+	status = "okay";
+	phy-mode = "sgmii";
+	phy-handle = <&qca8081>;
+	label = "wan";
+};
+
+&pcie_qmp0 {
+	status = "okay";
+};
+
+&pcie0 {
+	status = "okay";
+	pinctrl-0 = <&pcie0_default_state &pcie_sdx_gpio>;
+	pinctrl-names = "default";
+};
+
+&wifi {
+	status = "okay";
+
+	qcom,ath11k-calibration-variant = "Edgecore-EAP102";
+};

--- a/target/linux/qualcommax/image/ipq807x.mk
+++ b/target/linux/qualcommax/image/ipq807x.mk
@@ -177,6 +177,19 @@ define Device/edgecore_eap102
 endef
 TARGET_DEVICES += edgecore_eap102
 
+define Device/swaiot_s10sky
+	$(call Device/FitImage)
+	$(call Device/UbiFit)
+	DEVICE_VENDOR := Swaiot
+	DEVICE_MODEL := S10-SKY
+	BLOCKSIZE := 128k
+	PAGESIZE := 2048
+	DEVICE_DTS_CONFIG := config@ac02
+	SOC := ipq8071
+	DEVICE_PACKAGES := ipq-wifi-edgecore_eap102
+endef
+TARGET_DEVICES += swaiot_s10sky
+
 define Device/edimax_cax1800
 	$(call Device/FitImage)
 	$(call Device/UbiFit)

--- a/target/linux/qualcommax/ipq807x/base-files/etc/board.d/02_network
+++ b/target/linux/qualcommax/ipq807x/base-files/etc/board.d/02_network
@@ -86,6 +86,9 @@ ipq807x_setup_interfaces()
 	zyxel,nwa210ax)
 		ucidef_set_interface_lan "uplink lan1" "dhcp"
 		;;
+	swaiot,s10sky)
+		ucidef_set_interfaces_lan_wan "lan1 lan2" "wan"
+		;;
 	*)
 		echo "Unsupported hardware. Network interfaces not initialized"
 		;;

--- a/target/linux/qualcommax/ipq807x/base-files/etc/hotplug.d/firmware/11-ath11k-caldata
+++ b/target/linux/qualcommax/ipq807x/base-files/etc/hotplug.d/firmware/11-ath11k-caldata
@@ -20,6 +20,7 @@ case "$FIRMWARE" in
 	compex,wpq873|\
 	dynalink,dl-wrx36|\
 	edgecore,eap102|\
+	swaiot,s10sky|\
 	edimax,cax1800|\
 	netgear,rax120v2|\
 	netgear,rbr750|\

--- a/target/linux/qualcommax/ipq807x/base-files/lib/upgrade/platform.sh
+++ b/target/linux/qualcommax/ipq807x/base-files/lib/upgrade/platform.sh
@@ -56,6 +56,7 @@ platform_do_upgrade() {
 	compex,wpq873|\
 	dynalink,dl-wrx36|\
 	edimax,cax1800|\
+	swaiot,s10sky|\
 	netgear,rax120v2|\
 	netgear,rbr750|\
 	netgear,rbs750|\


### PR DESCRIPTION
## Summary
- add `Swaiot S10-SKY` device support for `qualcommax/ipq807x`
- wire the board into image generation, network setup, ath11k caldata reuse, and NAND upgrade handling
- reuse the existing `Edgecore EAP102` ath11k calibration package without copying its special dual-slot upgrade flow

## Verification
- static adaptation only, per request
- checked the new board wiring in DTS, `ipq807x.mk`, `02_network`, `11-ath11k-caldata`, and `platform.sh`
- confirmed `01_leds`, `qualcommax_ipq807x`, `bootcount`, and `package/firmware/ipq-wifi/Makefile` were intentionally left unchanged

Closes #336