### PR TITLE
mac80211: fix NSS mesh offload patch on backports 6.18.26

### DIFF
--- a/package/kernel/mac80211/patches/nss/subsys/300-ath11k-nss-mesh-offload-support.patch
+++ b/package/kernel/mac80211/patches/nss/subsys/300-ath11k-nss-mesh-offload-support.patch
@@ -120,28 +120,6 @@ Signed-off-by: Gautham Kumar Senthilkumaran <quic_gauthamk@quicinc.com>
  
  	/* keep last, obviously */
  	NUM_IEEE80211_HW_FLAGS
-@@ -4520,6 +4541,8 @@ struct ieee80211_prep_tx_info {
-  * @set_sar_specs: Update the SAR (TX power) settings.
-  * @sta_set_decap_offload: Called to notify the driver when a station is allowed
-  *	to use rx decapsulation offload
-+ * @config_mesh_offload_path: Configure mesh path table when driver supports mesh offload.
-+ *	This calback must be atomic.
-  * @add_twt_setup: Update hw with TWT agreement parameters received from the peer.
-  *	This callback allows the hw to check if requested parameters
-  *	are supported and if there is enough room for a new agreement.
-@@ -4935,6 +4958,12 @@ struct ieee80211_ops {
- 	void (*sta_set_decap_offload)(struct ieee80211_hw *hw,
- 				      struct ieee80211_vif *vif,
- 				      struct ieee80211_sta *sta, bool enabled);
-+#ifdef CPTCFG_MAC80211_MESH
-+	void (*config_mesh_offload_path)(struct ieee80211_hw *hw,
-+					 struct ieee80211_vif *vif,
-+					 enum ieee80211_mesh_path_offld_cmd cmd,
-+					 struct ieee80211_mesh_path_offld *path);
-+#endif
- 	void (*add_twt_setup)(struct ieee80211_hw *hw,
- 			      struct ieee80211_sta *sta,
- 			      struct ieee80211_twt_setup *twt);
 @@ -8004,4 +8033,101 @@ int ieee80211_emulate_switch_vif_chanctx
   * Return: %true iff the vif is a NAN interface and NAN is started
   */

--- a/package/kernel/mac80211/patches/nss/subsys/301-fix-mesh-offload-mac80211h-6.18.26.patch
+++ b/package/kernel/mac80211/patches/nss/subsys/301-fix-mesh-offload-mac80211h-6.18.26.patch
@@ -1,0 +1,15 @@
+--- a/include/net/mac80211.h
++++ b/include/net/mac80211.h
+@@ -4964,6 +4964,12 @@
+ 	void (*sta_set_decap_offload)(struct ieee80211_hw *hw,
+ 				      struct ieee80211_vif *vif,
+ 				      struct ieee80211_sta *sta, bool enabled);
++#ifdef CPTCFG_MAC80211_MESH
++	void (*config_mesh_offload_path)(struct ieee80211_hw *hw,
++					 struct ieee80211_vif *vif,
++					 enum ieee80211_mesh_path_offld_cmd cmd,
++					 struct ieee80211_mesh_path_offld *path);
++#endif
+ 	void (*sta_set_airtime_weight)(struct ieee80211_hw *hw,
+ 				       struct ieee80211_vif *vif,
+ 				       struct ieee80211_sta *sta, u16 weight);


### PR DESCRIPTION
Fix mac80211 NSS mesh offload patch failure on backports 6.18.26.

The build currently fails while applying:

`package/kernel/mac80211/patches/nss/subsys/300-ath11k-nss-mesh-offload-support.patch`

The failing hunks are in `include/net/mac80211.h`. The `struct ieee80211_ops` layout changed in current `backports-6.18.26`, so the old hunk no longer applies cleanly.

Changes:

* remove the stale failing `include/net/mac80211.h` hunk from `300-ath11k-nss-mesh-offload-support.patch`
* add `301-fix-mesh-offload-mac80211h-6.18.26.patch`
* re-add `config_mesh_offload_path` at the correct location for current `backports-6.18.26`

Tested:

* branch: `main-nss`
* target: `qualcommax/ipq60xx`
* backports: `6.18.26`
* `make package/kernel/mac80211/compile -j1 V=s` passed
* full firmware build passed locally
