### PR TITLE
qualcommax: ipq807x: refactor sfp_link_speed init script

### DIFF
--- a/target/linux/qualcommax/ipq807x/base-files/etc/init.d/sfp_link_speed
+++ b/target/linux/qualcommax/ipq807x/base-files/etc/init.d/sfp_link_speed
@@ -5,59 +5,81 @@ STOP=90
 
 USE_PROCD=1
 
-# SFP 接口名与 SSDK 端口号的对应关系（来自 DTS 的 port_id）。
-# lan5 = dp6_syn = SSDK port 6
-# lan6 = dp5_syn = SSDK port 5
+# SFP 接口名与 SSDK 端口号的对应关系（来自 DTS 的 port_id）：
+#   lan5 = dp6_syn = SSDK port 6
+#   lan6 = dp5_syn = SSDK port 5
+sfp_port() {
+	case "$1" in
+	lan5) echo 6 ;;
+	lan6) echo 5 ;;
+	*) return 1 ;;
+	esac
+}
+
+# 用户配置的 sfp_speed 到 SSDK SerDes 模式的映射：
+#   1   -> sgmii_fiber (1G)
+#   2   -> sgmii_plus  (2.5G / HSGMII)
+#   10  -> 10gbase_r   (10G)
+#   空   -> 10gbase_r   (默认，兼容 LuCI 空值表示 10G)
+sfp_mode() {
+	case "$1" in
+	1) echo sgmii_fiber ;;
+	2) echo sgmii_plus ;;
+	10|'') echo 10gbase_r ;;
+	*) return 1 ;;
+	esac
+}
+
+# 加入待处理列表；同一端口只记录一次，避免重复 set。
+sfp_pending_add() {
+	case " $sfp_pending " in
+	*" $1:"*) return 0 ;;
+	esac
+	sfp_pending="$sfp_pending $1:$2"
+}
+
 sfp_speed_device_cb() {
-	local name speed mode port
+	local name speed port mode
 
 	config_get name "$1" name
 	[ -n "$name" ] || name="$1"
 	[ -n "$name" ] || return 0
 
+	port=$(sfp_port "$name") || return 0
 	config_get speed "$1" sfp_speed
-	case "$speed" in
-	1) mode="sgmii_fiber" ;;
-	2) mode="sgmii_plus" ;;
-	10) mode="10gbase_r" ;;
-	*) return 0 ;;
-	esac
+	mode=$(sfp_mode "$speed") || return 0
 
-	case "$name" in
-	lan5) port=6 ;;
-	lan6) port=5 ;;
-	*) return 0 ;;
-	esac
-
-	sfp_commands="$sfp_commands\n$name $port $mode"
+	sfp_pending_add "$port" "$mode"
 }
 
 start_service() {
 	[ "$(board_name)" = "tplink,tl-er2260t" ] || return 0
 
-	sfp_commands=""
+	sfp_pending=""
 	config_load network
 	config_foreach sfp_speed_device_cb device
 
-	[ -n "$sfp_commands" ] || return 0
+	# 兜底：未显式配置的 SFP 端口默认强制 10G，避免 host-side 链路起不来。
+	for port in 5 6; do
+		sfp_pending_add "$port" 10gbase_r
+	done
 
-	local ifname port mode applied=0
+	local entry port mode applied=0
 
-	while read -r ifname port mode; do
-		[ -n "$ifname" ] || continue
-		if ssdk_sh port interfaceMode set "$port" "$mode" 2>/dev/null; then
-			logger -t "SFP Speed" "Set $ifname (SSDK port $port) to $mode."
+	for entry in $sfp_pending; do
+		port=${entry%%:*}
+		mode=${entry#*:}
+		if ssdk_sh port interfaceMode set "$port" "$mode" >/dev/null 2>&1; then
+			logger -t "SFP Speed" "Set SSDK port $port to $mode."
 			applied=1
 		else
-			logger -t "SFP Speed" "Failed to set $ifname (SSDK port $port) to $mode."
+			logger -t "SFP Speed" "Failed to set SSDK port $port to $mode."
 		fi
-	done <<EOF
-$(printf '%b' "$sfp_commands")
-EOF
+	done
 
 	[ "$applied" -eq 1 ] || return 0
 
-	if ssdk_sh port interfaceMode apply 2>/dev/null; then
+	if ssdk_sh port interfaceMode apply >/dev/null 2>&1; then
 		logger -t "SFP Speed" "Interface mode applied."
 	else
 		logger -t "SFP Speed" "Failed to apply interface mode."


### PR DESCRIPTION
## 一、sfp_link_speed 脚本优化

文件：`target/linux/qualcommax/ipq807x/base-files/etc/init.d/sfp_link_speed`

原脚本仅支持把 network 配置里的 `sfp_speed` 硬编码映射为 SSDK 接口模式，用 heredoc 拼接命令再逐行解析。本次重构：

1. **函数化**：提取 `sfp_port()`（接口名 → SSDK 端口号映射，lan5→6, lan6→5）和 `sfp_mode()`（配置值 → SerDes 模式映射：1→sgmii_fiber, 2→sgmii_plus, 10→10gbase_r）。
2. **简化数据处理**：用空格分隔的 `sfp_pending` 列表替代 heredoc + `printf %b` 的复杂解析，逐项直接拆解 `port:mode`。
3. **未配置端口兜底**：未显式配置 `sfp_speed` 的 SFP 端口默认强制 `10gbase_r`，避免 host-side 链路起不来（原脚本会直接跳过）。
4. **兼容 LuCI 空值**：`sfp_mode` 将空值映射为 `10gbase_r`，与 LuCI 留空即 10G 的语义一致。
5. **端口去重**：`sfp_pending_add` 保证同一端口只记录一次，防止兜底逻辑覆盖已手动指定的配置。
6. **统一日志与重定向**：所有 `ssdk_sh` 调用统一 `>/dev/null 2>&1`，日志格式统一为 `SSDK port <n>`。

## 二、LuCI 补丁内容

补丁文件：`feeds/luci/modules/luci-mod-network/patches/001-tplink-tl-er2260t-sfp-speed-manual.patch`

作用文件：`htdocs/luci-static/resources/tools/network.js`

在设备高级设置区（`devadvanced`）新增 `sfp_speed` 下拉选项：

```js
o = this.replaceOption(s, 'devadvanced', form.ListValue, 'sfp_speed', _('SFP link speed'),
    _('Force the SFP host-side SerDes mode. Only effective on devices with an SFP port (e.g. TP-Link TL-ER2260T).'));
o.value('1', _('1 Gbps (SGMII)'));
o.value('2', _('2.5 Gbps (SGMII+ / HSGMII)'));
o.value('10', _('10 Gbps (10GBASE-R)'));
o.rmempty = true;
o.depends('name_simple', 'lan5');
o.depends('name_simple', 'lan6');
o.depends('name_complex', 'lan5');
o.depends('name_complex', 'lan6');
```

- 档位：1 Gbps (SGMII) / 2.5 Gbps (SGMII+ / HSGMII) / 10 Gbps (10GBASE-R)
- 仅在设备名为 `lan5` / `lan6` 时显示
- 选择值写入 network 配置的 `sfp_speed`，由固件脚本读取应用

## 三、补丁应放在哪个位置

该补丁必须放在 **luci-mod-network 包的 `patches/` 目录**，由 OpenWrt 构建系统的 quilt/patch 机制在编译时自动应用：

```
feeds/luci/modules/luci-mod-network/patches/001-tplink-tl-er2260t-sfp-speed-manual.patch
feeds/luci/modules/luci-mod-network/patches/series
```

- `series` 文件列出要应用的补丁（`001-tplink-tl-er2260t-sfp-speed-manual.patch`），避免 `patches/` 目录内其他文件被误当作补丁。
- 重新编译生效：`make package/feeds/luci/luci-mod-network/compile`
