### PR TITLE
uboot-envtools: fix Xiaomi IPQ60xx env size for fw_printenv

### DIFF
--- a/package/boot/uboot-tools/uboot-envtools/files/qualcommax_ipq60xx
+++ b/package/boot/uboot-tools/uboot-envtools/files/qualcommax_ipq60xx
@@ -25,8 +25,6 @@ cmiot,ax18|\
 kt,ar06-012h|\
 lg,gapd-7500|\
 qihoo,360v6|\
-redmi,ax5|\
-xiaomi,ax1800|\
 netgear,wax214|\
 netgear,wax610|\
 netgear,wax610y|\
@@ -34,6 +32,14 @@ tplink,eap610-outdoor|\
 tplink,eap623od-hd-v1|\
 tplink,eap625-outdoor-hd-v1)
 	ubootenv_add_mtd "0:appsblenv" "0x0" "0x40000" "0x20000"
+	;;
+# Xiaomi IPQ60xx devices store a 64 KiB environment: the CRC32 stored in the
+# first 4 bytes covers 0x04..0x10000.  A larger env size makes fw_printenv
+# report "Bad CRC, using default environment" and fw_setenv rewrite the
+# environment from defaults, wiping vendor variables.
+redmi,ax5|\
+xiaomi,ax1800)
+	ubootenv_add_mtd "0:appsblenv" "0x0" "0x10000" "0x20000"
 	;;
 yuncore,fap650)
 	ubootenv_add_mtd "0:appsblenv" "0x0" "0x10000" "0x10000"


### PR DESCRIPTION
## Problem

On Redmi AX5 (and the hardware-identical Xiaomi AX1800), `fw_printenv` always reports:

```
Warning: Bad CRC, using default environment
```

and `fw_setenv` silently rewrites the environment from the built-in defaults, **wiping vendor variables** (`flag_boot_rootfs`, `SN`, `miot_key`, SSIDs, ...).

## Root cause

Xiaomi IPQ60xx devices store a **64 KiB** u-boot environment whose CRC32 (first 4 bytes) covers `0x04..0x10000` (verified from the vendor u-boot env layout, e.g. `bdata`):

```
[CRC32 LE of 0x04..0x10000][key=value\0...][0x00 padding]
```

The current entry uses `0x40000` as env size. `fw_printenv` then computes the CRC over `0x04..0x40000` (including padding/erased area), which never matches, hence the perpetual "Bad CRC".

## Fix

Move `redmi,ax5` / `xiaomi,ax1800` to their own case with `0x10000` env size, leaving all other ipq60xx devices (zn,m2, cmiot, netgear, tplink, ...) untouched.

## Verification (on device, Redmi AX5, LibWrt 25.12)

- `fw_printenv` now dumps all 60 vendor variables (`flag_boot_rootfs`, `SN`, `bootargs`, ...) correctly
- `fw_setenv` read/write round-trip works, existing variables preserved
- After `fw_setenv`, the stored CRC still equals `crc32(0, data[4:0x10000])` — the written format stays compatible with the stock Xiaomi u-boot
- `sh -n` passes