### PR TITLE
uboot-envtools: fix Xiaomi IPQ60xx env size for fw_printenv

### DIFF
--- a/package/boot/uboot-tools/uboot-envtools/files/qualcommax_ipq60xx
+++ b/package/boot/uboot-tools/uboot-envtools/files/qualcommax_ipq60xx
@@ -25,8 +25,6 @@ cmiot,ax18|\
 kt,ar06-012h|\
 lg,gapd-7500|\
 qihoo,360v6|\
-redmi,ax5|\
-xiaomi,ax1800|\
 netgear,wax214|\
 netgear,wax610|\
 netgear,wax610y|\
@@ -34,6 +32,14 @@ tplink,eap610-outdoor|\
 tplink,eap623od-hd-v1|\
 tplink,eap625-outdoor-hd-v1)
 	ubootenv_add_mtd "0:appsblenv" "0x0" "0x40000" "0x20000"
+	;;
+# Xiaomi IPQ60xx devices store a 64 KiB environment: the CRC32 stored in the
+# first 4 bytes covers 0x04..0x10000.  A larger env size makes fw_printenv
+# report "Bad CRC, using default environment" and fw_setenv rewrite the
+# environment from defaults, wiping vendor variables.
+redmi,ax5|\
+xiaomi,ax1800)
+	ubootenv_add_mtd "0:appsblenv" "0x0" "0x10000" "0x20000"
 	;;
 yuncore,fap650)
 	ubootenv_add_mtd "0:appsblenv" "0x0" "0x10000" "0x10000"

--- a/package/boot/uboot-tools/uboot-envtools/files/qualcommax_ipq60xx
+++ b/package/boot/uboot-tools/uboot-envtools/files/qualcommax_ipq60xx
@@ -33,10 +33,6 @@ tplink,eap623od-hd-v1|\
 tplink,eap625-outdoor-hd-v1)
 	ubootenv_add_mtd "0:appsblenv" "0x0" "0x40000" "0x20000"
 	;;
-# Xiaomi IPQ60xx devices store a 64 KiB environment: the CRC32 stored in the
-# first 4 bytes covers 0x04..0x10000.  A larger env size makes fw_printenv
-# report "Bad CRC, using default environment" and fw_setenv rewrite the
-# environment from defaults, wiping vendor variables.
 redmi,ax5|\
 xiaomi,ax1800)
 	ubootenv_add_mtd "0:appsblenv" "0x0" "0x10000" "0x20000"


### PR DESCRIPTION
Redmi AX5 / Xiaomi AX1800 store a 64 KiB u-boot environment whose CRC32 (first 4 bytes) covers `0x04..0x10000`. The current `0x40000` env size makes `fw_printenv` always report "Bad CRC, using default environment" and makes `fw_setenv` rewrite the environment from defaults, wiping vendor variables.

Move `redmi,ax5` / `xiaomi,ax1800` to their own case with `0x10000` env size; other ipq60xx devices are unchanged.

Verified on a Redmi AX5 (LibWrt 25.12): `fw_printenv` reads all vendor variables, `fw_setenv` round-trip works, and the written CRC still matches `crc32(0, data[4:0x10000])`, keeping stock u-boot compatibility.