### PR TITLE
uboot-envtools: 修复小米 IPQ60xx（Redmi AX5/AX1800）u-boot env 大小配置

### DIFF
--- a/package/boot/uboot-tools/uboot-envtools/files/qualcommax_ipq60xx
+++ b/package/boot/uboot-tools/uboot-envtools/files/qualcommax_ipq60xx
@@ -25,8 +25,6 @@ cmiot,ax18|\
 kt,ar06-012h|\
 lg,gapd-7500|\
 qihoo,360v6|\
-redmi,ax5|\
-xiaomi,ax1800|\
 netgear,wax214|\
 netgear,wax610|\
 netgear,wax610y|\
@@ -34,6 +32,10 @@ tplink,eap610-outdoor|\
 tplink,eap623od-hd-v1|\
 tplink,eap625-outdoor-hd-v1)
 	ubootenv_add_mtd "0:appsblenv" "0x0" "0x40000" "0x20000"
+	;;
+redmi,ax5|\
+xiaomi,ax1800)
+	ubootenv_add_mtd "0:appsblenv" "0x0" "0x10000" "0x20000"
 	;;
 yuncore,fap650)
 	ubootenv_add_mtd "0:appsblenv" "0x0" "0x10000" "0x10000"


### PR DESCRIPTION
## 问题

在 Redmi AX5 上，`fw_printenv` 一直报：

```
Warning: Bad CRC, using default environment
```

## 为什么 AX5 要这么改（背景）

小米 IPQ60xx 设备（Redmi AX5 与硬件完全相同的 Xiaomi AX1800）的 u-boot env 存储格式与标准 u-boot 不同：

- env 分区（`0:appsblenv`）实际只有 **64 KiB（0x10000）** 有效
- 头部 4 字节是 **CRC32**，其计算范围是 `0x04..0x10000`（整块，含填充）
- 数据区是 `key=value\0` 序列

```
[CRC32 LE，覆盖 0x04..0x10000][key=value\0...][0x00 填充到 0x10000]
```

`fw_printenv` 的 CRC 校验范围 = **配置的 env 大小 − 4**。原配置写的是 `0x40000`，导致校验范围变成 `0x04..0x40000`（把擦除态/无用区域也算进去了），永远对不上 → 永远 Bad CRC。

## 修复

把 `redmi,ax5` / `xiaomi,ax1800` 从 `0x40000` 的公共分支中拆出，单独使用正确的 `0x10000` env 大小。

## 验证（Redmi AX5 实测，LibWrt 25.12）

1. 修改 `/etc/fw_env.config` 的 env 大小后，`fw_printenv` 正常输出全部 60 个厂商变量（`flag_boot_rootfs`、`bootargs`、`SN` 等）
2. `fw_setenv` 写入/读取往返正常，原有变量完整保留
3. `fw_setenv` 写完后，头部 CRC 仍精确等于 `crc32(0, data[4:0x10000])`——写入格式与小米原厂 u-boot 完全兼容，互不破坏